### PR TITLE
Fix build error with Mikero's PBO tool with a re-difined objects

### DIFF
--- a/build/build.sh
+++ b/build/build.sh
@@ -1,8 +1,8 @@
 #!/usr/bin/env bash
 # by Vitalii B.
-# Dependencies: Mikero DePbo Tools v.0.7.70 or later
+# Dependencies: Mikero DePbo Tools v.0.7.92 or later
 # Download page: https://mikero.bytex.digital/Downloads
-# Direct link: https://mikero.bytex.digital/api/download?filename=depbo-tools-0.7.70-linux-64bit.tgz
+# Direct link: https://mikero.bytex.digital/api/download?filename=depbo-tools-0.7.92-linux-64bit.tgz
 echo -e "- Liberation_RX PBO build script -\n"
 
 which makepbo &>/dev/null
@@ -25,7 +25,7 @@ for dir in $(ls -1 ../maps | grep -E "^Liberation_RX\.*"); do
     if [[ -d custom ]]; then
 	cp -r ./custom/* ./${dir}/
     fi
-    makepbo -X=none ./${dir} ${dir}.pbo >/dev/null
+    makepbo -X=none ${dir} ${dir}.pbo >/dev/null
     rm -rf ./${dir}
     echo "Done."
 done

--- a/core.liberation/addons/MGR/Configs/defines.hpp
+++ b/core.liberation/addons/MGR/Configs/defines.hpp
@@ -51,6 +51,43 @@
 #define ST_UP             0x08
 #define ST_VCENTER        0x0C
 
+#ifdef ST_SINGLE
+#undef ST_SINGLE
+#endif
+#ifdef ST_MULTI
+#undef ST_MULTI
+#endif
+#ifdef ST_TITLE_BAR
+#undef ST_TITLE_BAR
+#endif
+#ifdef ST_PICTURE
+#undef ST_PICTURE
+#endif
+#ifdef ST_FRAME
+#undef ST_FRAME
+#endif
+#ifdef ST_BACKGROUND
+#undef ST_BACKGROUND
+#endif
+#ifdef ST_GROUP_BOX
+#undef ST_GROUP_BOX
+#endif
+#ifdef ST_GROUP_BOX2
+#undef ST_GROUP_BOX2
+#endif
+#ifdef ST_TILE_PICTURE
+#undef ST_TILE_PICTURE
+#endif
+#ifdef ST_WITH_RECT
+#undef ST_WITH_RECT
+#endif
+#ifdef ST_LINE
+#undef ST_LINE
+#endif
+#ifdef ST_HUD_BACKGROUND
+#undef ST_HUD_BACKGROUND
+#endif
+
 #define ST_TYPE           0xF0
 #define ST_SINGLE         0x00
 #define ST_MULTI          0x10


### PR DESCRIPTION
Hi. Please, pay attention also to these warnings, produces by Mikero's PBO tool while building your mission. Maybe it is better to follow his advice?

```
Warning only: #define CT_List_N_Box is not FULL_UPPER_CASE, fix it if you can, or regret it later.

Warning only: #define FontM is not FULL_UPPER_CASE, fix it if you can, or regret it later.

Warning only: #define CT_List_N_Box is not FULL_UPPER_CASE, fix it if you can, or regret it later.

Warning only: #define FontM is not FULL_UPPER_CASE, fix it if you can, or regret it later.

Warning only: #define R3F_LOG_enable is not FULL_UPPER_CASE, fix it if you can, or regret it later.

Warning only: #define R3F_LOG_ID_transporteur_START is not FULL_UPPER_CASE, fix it if you can, or regret it later.

Warning only: #define R3F_LOG_IDD_dlg_contenu_vehicule is not FULL_UPPER_CASE, fix it if you can, or regret it later.

Warning only: #define R3F_LOG_IDC_dlg_CV_capacite_vehicule is not FULL_UPPER_CASE, fix it if you can, or regret it later.

Warning only: #define R3F_LOG_IDC_dlg_CV_liste_contenu is not FULL_UPPER_CASE, fix it if you can, or regret it later.

Warning only: #define R3F_LOG_IDC_dlg_CV_btn_decharger is not FULL_UPPER_CASE, fix it if you can, or regret it later.

Warning only: #define R3F_LOG_IDC_dlg_CV_titre is not FULL_UPPER_CASE, fix it if you can, or regret it later.

Warning only: #define R3F_LOG_IDC_dlg_CV_credits is not FULL_UPPER_CASE, fix it if you can, or regret it later.

Warning only: #define R3F_LOG_IDC_dlg_CV_btn_fermer is not FULL_UPPER_CASE, fix it if you can, or regret it later.

Warning only: #define R3F_LOG_IDC_dlg_CV_jauge_chargement is not FULL_UPPER_CASE, fix it if you can, or regret it later.

Warning only: #define CT_List_N_Box is not FULL_UPPER_CASE, fix it if you can, or regret it later.

Warning only: #define R3F_LOG_dlg_CV_jauge_chargement_h is not FULL_UPPER_CASE, fix it if you can, or regret it later.

Warning only: #define GUI_GRID_WAbs is not FULL_UPPER_CASE, fix it if you can, or regret it later.

Warning only: #define GUI_GRID_HAbs is not FULL_UPPER_CASE, fix it if you can, or regret it later.

Warning only: #define DALE_var_dlgWidthImg is not FULL_UPPER_CASE, fix it if you can, or regret it later.

Warning only: #define DALE_var_dlgHeightImg is not FULL_UPPER_CASE, fix it if you can, or regret it later.

Warning only: #define DALE_var_dlgWidthSection is not FULL_UPPER_CASE, fix it if you can, or regret it later.

Warning only: #define DALE_var_dlgHeightSection is not FULL_UPPER_CASE, fix it if you can, or regret it later.
```