### PR TITLE
fix for no "ammo" being removed

### DIFF
--- a/core.liberation/scripts/client/actions/do_buyfuel.sqf
+++ b/core.liberation/scripts/client/actions/do_buyfuel.sqf
@@ -6,6 +6,10 @@ if (_result) then {
 	if (!([_cost] call F_pay)) exitWith {};
 	private _pos = player modelToWorld [0,1,1];
 	private _can = createVehicle [canisterFuel, _pos, [], 0, "CAN_COLLIDE"];
-	[_can] spawn R3F_LOG_FNCT_objet_deplacer;
+	if (GRLIB_ACE_enabled) then {
+		[_can, true] call ace_dragging_fnc_setCarryable;
+	} else {
+		[_can] spawn R3F_LOG_FNCT_objet_deplacer;	
+	};
 	hintSilent localize "STR_FUEL_READY";
 };

--- a/core.liberation/scripts/client/spawn/redeploy_manager.sqf
+++ b/core.liberation/scripts/client/spawn/redeploy_manager.sqf
@@ -157,6 +157,8 @@ if (dialog && deploy == 1) then {
 	if ( !GRLIB_player_spawned ) then {	
 		// respawn loadout
 		if ( !isNil "GRLIB_respawn_loadout" ) then {
+			GRLIB_backup_loadout = GRLIB_default_loadout;
+			player setVariable ["GREUH_stuff_price", GRLIB_default_price];
 			[player, GRLIB_respawn_loadout] call F_setLoadout;
 		} else {
 			// init loadout
@@ -170,8 +172,10 @@ if (dialog && deploy == 1) then {
 					[player, configOf player] call BIS_fnc_loadInventory;
 				};
 			};
-			player setVariable ["GREUH_stuff_price", ([player] call F_loadoutPrice)];
+			GRLIB_default_price = [player] call F_loadoutPrice;
+			player setVariable ["GREUH_stuff_price", GRLIB_default_price];
 			GRLIB_backup_loadout = [player] call F_getLoadout;
+			GRLIB_default_loadout = GRLIB_backup_loadout;
 		};
 		[player] call F_filterLoadout;
 		[player] call F_payLoadout;


### PR DESCRIPTION
Small changes to fix "ammo" not being removed when using "Respawn Loadout", it first saves a default loadout/price when spawn, and then when respawn with "Respawn Loadout" it changed the backup loadout to the default one so if you dont have enough money it changes to that. And also sets the "old price" to default price.