### PR TITLE
Adds markers to surrendering AI units

### DIFF
--- a/core.liberation/scripts/server/ai/prisonner_ai.sqf
+++ b/core.liberation/scripts/server/ai/prisonner_ai.sqf
@@ -26,7 +26,7 @@ _unit setVariable ["GRLIB_can_speak", true, true];
 
 //Create a marker to make them easier to locate.
 _mPos = position _unit;
-_mName = "CaptiveMarker" + str _mPos;
+_mName = "CaptiveMarker" + (str _mPos);
 _captiveMarker = createMarker [_mName,_mPos];
 _mName setMarkerTypeLocal "hd_objective";
 _mName setMarkerText "Surrendering Unit";

--- a/core.liberation/scripts/server/ai/prisonner_ai.sqf
+++ b/core.liberation/scripts/server/ai/prisonner_ai.sqf
@@ -24,6 +24,13 @@ if (!_canmove) then {
 _unit setVariable ["GRLIB_is_prisonner", true, true];
 _unit setVariable ["GRLIB_can_speak", true, true];
 
+//Create a marker to make them easier to locate.
+_mPos = position _unit;
+_mName = "CaptiveMarker" + str _mPos;
+_captiveMarker = createMarker [_mName,_mPos];
+_mName setMarkerTypeLocal "hd_objective";
+_mName setMarkerText "Surrendering Unit";
+
 // Wait
 if (_friendly) then {
 	waitUntil { sleep 1; !alive _unit || side group _unit == GRLIB_side_friendly};
@@ -31,6 +38,9 @@ if (_friendly) then {
 	private _timeout = time + (20 * 60);
 	waitUntil { sleep 1; !alive _unit || side group _unit == GRLIB_side_friendly || time > _timeout };
 };
+
+//Remove the previous marker. Either they're dead, or have been captured.
+deleteMarker _mName;
 
 if (!alive _unit) exitWith {};
 


### PR DESCRIPTION
The AI surrender script now creates a simple objective marker on surrendering AI to allow players to locate them easier after battles, to allow for less tedious post-battle cleanup. 

As-is, finding surrendered enemies in built-up areas, forests, or any highly obstructive terrain is an exercise in boredom and transporting + corraling them back to base already provides the downtime needed for enemy attack timers and such to tick onwards.