### PR TITLE
Refactor medic functions for improved logic and readability;

### DIFF
--- a/core.liberation/addons/PAR/PAR_fn_checkMedic.sqf
+++ b/core.liberation/addons/PAR/PAR_fn_checkMedic.sqf
@@ -39,10 +39,10 @@ while {
 		alive _medic && 
 		([_wnded] call PAR_is_wounded) && 
 		!([_medic] call PAR_is_wounded) && 
-		(_wnded getVariable "PAR_myMedic") isEqualTo _medic && 
 		_fail <= 12 &&
-		vehicle _medic == _medic &&
-		vehicle _wnded == _wnded
+		vehicle _medic isEqualTo _medic &&
+		vehicle _wnded isEqualTo _wnded &&
+		(_wnded getVariable ["PAR_myMedic", objNull]) isEqualTo _medic
 	} do {
 	_msg = "";
 

--- a/core.liberation/addons/PAR/PAR_fn_checkMedic.sqf
+++ b/core.liberation/addons/PAR/PAR_fn_checkMedic.sqf
@@ -34,12 +34,24 @@ private _check_sortie = {
 private _healed = false;
 // we want ALL of these conditions to be satisfied to keep this loop going, not just one of them
 // We also want to make sure this loop is only running while the medic is still the woundeds current medic
-while { ([_wnded] call PAR_is_wounded) && !([_medic] call PAR_is_wounded) && (_wnded getVariable "PAR_myMedic") isEqualTo _medic && _fail <= 12 } do {
+while { 
+		alive _wnded && 
+		alive _medic && 
+		([_wnded] call PAR_is_wounded) && 
+		!([_medic] call PAR_is_wounded) && 
+		(_wnded getVariable "PAR_myMedic") isEqualTo _medic && 
+		_fail <= 12 &&
+		vehicle _medic == _medic &&
+		vehicle _wnded == _wnded
+	} do {
 	_msg = "";
+
+	if ([_wnded, _medic] call _check_sortie) exitWith {
+		_healed = true;
+	};
 	_dist = round (_wnded distance2D _medic);
 	// systemchat format ["dbg: wnded 2D dist : %1 dist speed %2 fail %3", _wnded distance2D _medic, round (speed vehicle _medic), _fail];
 	if (_dist > 500) exitWith {};
-	if (vehicle _medic != _medic || vehicle _wnded != _wnded) exitWith {};
 	//Lets lets the player decide if they want to keep looking for new medics, or if they would rather just respawn at this point
 	if (!isPlayer _medic) then {
 		_new_medic = [_wnded] call PAR_fn_nearestMedic;
@@ -48,14 +60,6 @@ while { ([_wnded] call PAR_is_wounded) && !([_medic] call PAR_is_wounded) && (_w
 				_wnded setVariable ["PAR_myMedic", nil];
 			};
 		};
-	};
-
-	// This was contradicting the above check, so my edit makes sense with this logic
-	if (isNil {
-		_wnded getVariable "PAR_myMedic";
-	}) exitWith {};
-	if ([_wnded, _medic] call _check_sortie) exitWith {
-		_healed = true;
 	};
 
 	if (round (speed vehicle _medic) == 0) then {
@@ -109,7 +113,9 @@ while { ([_wnded] call PAR_is_wounded) && !([_medic] call PAR_is_wounded) && (_w
 		if (_fail == 0) then {
 			_msg = format [localize "STR_PAR_CM_02", name _wnded, name _medic, _dist, round (speed vehicle _medic)];
 		};
-		[_wnded, _msg] call PAR_fn_globalchat;
+		if (!(_msg isEqualTo "")) then {
+			[_wnded, _msg] call PAR_fn_globalchat;
+		};
 		_cnt = 3;
 	} else {
 		_cnt = _cnt - 1;

--- a/core.liberation/addons/PAR/PAR_fn_medicRecall.sqf
+++ b/core.liberation/addons/PAR/PAR_fn_medicRecall.sqf
@@ -1,4 +1,27 @@
 ((findDisplay 5566) displayCtrl 679) ctrlEnable false;
-player setVariable ["PAR_myMedic", nil];
-sleep 5;
+_unit = player;
+// Lets change the recall medic button to also manually summon a new medic
+if ( {
+    alive _x
+} count PAR_AI_bros > 0 ) then {
+    _unit setVariable ["PAR_myMedic", nil];
+    _unit groupchat localize "STR_PAR_UC_01";
+    _medic = [_unit] call PAR_fn_medic;
+    if (!isNil "_medic") then {
+        [_unit, _medic] call PAR_fn_911;
+    };
+    
+} else {
+    _msg = format [localize "STR_PAR_UC_03", name _unit];
+    if (lifeState _unit == "INCAPACITATED") then {
+        _msg = format [localize "STR_PAR_UC_02", name _unit];
+    };
+    _last_msg = _unit getVariable ["PAR_last_message", 0];
+    if (time > _last_msg) then {
+        [_unit, _msg] call PAR_fn_globalchat;
+        _unit setVariable ["PAR_last_message", round(time + 20)];
+    };
+};
+
+uiSleep 60;
 ((findDisplay 5566) displayCtrl 679) ctrlEnable true;

--- a/core.liberation/addons/PAR/PAR_fn_medicRelease.sqf
+++ b/core.liberation/addons/PAR/PAR_fn_medicRelease.sqf
@@ -4,7 +4,8 @@ private _release_medic = {
 	params ["_medic"];
 	if (!local _medic || isNull _medic) exitWith {};
 	_medic setUnitPos "AUTO";
-	{_medic enableAI _x} count ["TARGET","AUTOTARGET","AUTOCOMBAT","SUPPRESSION"];
+	//Change to forEach, count is really meant for specifying an expression to return scalar, the code in here generaly should only be a boolean expression return
+	{_medic enableAI _x} forEach ["TARGET","AUTOTARGET","AUTOCOMBAT","SUPPRESSION"];
 	[_medic] joinSilent (_medic getVariable "PAR_AIgrp");
 
 	if ((_medic getVariable ["isLeader",false]) && (isplayer _medic)) then {

--- a/core.liberation/addons/PAR/PAR_fn_nearestMedic.sqf
+++ b/core.liberation/addons/PAR/PAR_fn_nearestMedic.sqf
@@ -1,29 +1,54 @@
 params ["_wnded"];
 
-private _grp_id = _wnded getVariable ["PAR_Grp_ID","1"];
+private _grp_id = _wnded getVariable ["PAR_Grp_ID", "1"];
 private _medics = (units group _wnded) select {
-    ((_x getVariable ["PAR_Grp_ID","0"]) == _grp_id) &&
-    (_x distance2D _wnded <= 500) &&
-    !(isPlayer _x) && !([_x] call PAR_is_wounded) &&
-    !(objectParent _x iskindof "ParachuteBase") &&
-    isNil {_x getVariable "PAR_busy"}
+	((_x getVariable ["PAR_Grp_ID", "0"]) == _grp_id) &&
+	(_x distance2D _wnded <= 500) &&
+	!(isPlayer _x) && !([_x] call PAR_is_wounded) &&
+	!(objectParent _x iskindof "ParachuteBase") &&
+	isNil {
+		_x getVariable "PAR_busy"
+	}
 };
 
 if (count _medics == 0) exitWith {};
 
 // PAR Medikit/Firstkit
-if (PAR_revive == 2) then { _medics = _medics select {[_x] call PAR_has_medikit} };
+if (PAR_revive == 2) then {
+	_medics = _medics select {
+		[_x] call PAR_has_medikit
+	}
+};
 
 // PAR only medic
-if (PAR_revive == 3) then { _medics = _medics select {[_x] call PAR_is_medic} };
+if (PAR_revive == 3) then {
+	_medics = _medics select {
+		[_x] call PAR_is_medic
+	}
+};
+
+// lets prioritize those outside of vehicles
+_outside_veh = _medics select {
+	vehicle _x == _x;
+};
+if (count _outside_veh > 0) then {
+	_medics = _outside_veh;
+} else {
+	// Otherwise lets try to make sure they are not a gunner
+	private _notGunners = _medics select {
+		!("turret" == ((assignedVehicleRole _x)#0)) && gunner vehicle _x != _x && commander vehicle _x != _x;
+	};
+
+	if (count _notGunners > 0) then {
+		_medics = _notGunners
+	};
+};
 
 if (count _medics == 0) exitWith {};
 
-// (try to) keep gunner
-//private _medics_lst = _medics select { !("turret" in (assignedVehicleRole _x)) };
-//if (count _medics_lst == 0) then { _medics_lst = _medics };
-
-private _medics_sorted = _medics apply {[_x distance2D _wnded, _x]};
+private _medics_sorted = _medics apply {
+	[_x distance2D _wnded, _x]
+};
 _medics_sorted sort true;
 
 (_medics_sorted select 0 select 1);

--- a/core.liberation/addons/PAR/PAR_fn_unconscious.sqf
+++ b/core.liberation/addons/PAR/PAR_fn_unconscious.sqf
@@ -1,5 +1,31 @@
 params ["_unit"];
 
+
+_unitPos = getWPPos [_unit, 0];
+
+_units = units _unit;
+
+_unitWP = createHashMap;
+
+_group = group _unit;
+
+// Store all of the waypoints of group members before leader loses ownership of the squad
+if (leader _unit == _unit) then {
+	{
+		if (vehicle _x != _x) then {
+			_x disableAI "FSM";
+			_x disableAI "PATH";
+			_x setBehaviour "CARELESS";
+			//if any group members are already in a vehicle, add the vehicle to the group so that the ai leader is less likely to tell them to dismount
+			(group _x) addVehicle (vehicle _x);
+		};
+		_wp = getWPPos [_x, 0];
+		if !(_wp isEqualTo [0,0,0]) then {
+			_unitWP set [hashValue _x, _wp];
+		};
+	} forEach _units;
+};
+
 if (rating _unit < -2000) exitWith {_unit setDamage 1};
 if (!([] call F_getValid)) exitWith {_unit setDamage 1};
 private _cur_revive = 1;
@@ -17,6 +43,17 @@ _unit setVariable ["PAR_BleedOutTimer", round(time + PAR_bleedout), true];
 _unit setVariable ["PAR_isDragged", 0, true];
 
 if (isPlayer _unit) then {
+	//If an ai takes control of your squad, try to hold it still
+	_group removeAllEventHandlers "LeaderChanged";
+
+    _group addEventHandler ["LeaderChanged", {
+        params ["_group", "_newLeader"];
+        if (!isPlayer _newLeader) then {
+            {
+                doStop _x;
+            } forEach units _group;
+        };
+    }];
 	private _mk1 = createMarkerLocal [format ["PAR_marker_%1", PAR_Grp_ID], getPosATL player];
 	_mk1 setMarkerTypeLocal "loc_Hospital";
 	_mk1 setMarkerTextLocal format ["%1 Injured", name player];
@@ -42,7 +79,8 @@ private _bld = [_unit] call PAR_spawn_blood;
 private _cnt = 0;
 private ["_medic", "_msg"];
 while { alive _unit && ([_unit] call PAR_is_wounded) && time <= (_unit getVariable ["PAR_BleedOutTimer", 0])} do {
-	if (_cnt == 0) then {
+	// Stop automatically assigning medics to players, let the player decide
+	if (!isPlayer _unit) then {
 		_unit setOxygenRemaining 1;
 		if ( {alive _x} count PAR_AI_bros > 0 ) then {
 			_medic = _unit getVariable "PAR_myMedic";
@@ -62,11 +100,14 @@ while { alive _unit && ([_unit] call PAR_is_wounded) && time <= (_unit getVariab
 				player setVariable ["PAR_last_message", round(time + 20)];
 			};
 		};
-		//systemchat str ((_unit getVariable ["PAR_BleedOutTimer", 0]) - time);
-		_cnt = 10;
+	} else {
+		_medic = _unit getVariable ["PAR_myMedic", nil];
+        if (isNil "_medic") then {
+			//Renable the call medic button for the player if their medic gets lost
+            ((findDisplay 5566) displayCtrl 679) ctrlEnable true;
+        };
 	};
-	_cnt = _cnt - 1;
-	sleep 1;
+	sleep 10;
 };
 
 if (!isNull _bld) then { _bld spawn {sleep (30 + floor(random 30)); deleteVehicle _this} };
@@ -76,20 +117,36 @@ if (isPlayer _unit) then {
 	if (GRLIB_disable_death_chat) then { for "_channel" from 0 to 4 do { _channel enableChannel true } };
 };
 
-if (!alive _unit) exitWith {};
-
-// Bad end
-if (time > _unit getVariable ["PAR_BleedOutTimer", 0]) exitWith {
-	[(_unit getVariable ["PAR_myMedic", objNull]), _unit] call PAR_fn_medicRelease;
-	_unit setDamage 1;
+if (alive _unit) then {
+    if (time > _unit getVariable ["PAR_BleedOutTimer", 0]) then {
+		//Too late
+        _unit setDamage 1;
+        [(_unit getVariable ["PAR_myMedic", objNull]), _unit] call PAR_fn_medicRelease;
+    } else {
+		//Revived
+        if (isPlayer _unit) then {
+            (group _unit) selectLeader _unit;
+            if (primaryWeapon _unit != "") then {
+                _unit selectWeapon primaryWeapon _unit
+            };
+        } else {
+            _unit setVariable ["GRLIB_can_speak", true, true];
+            _unit setSpeedMode (speedMode group player);
+            _unit doFollow player;
+        };
+    };
 };
 
-// Good end
-if (isPlayer _unit) then {
-	(group _unit) selectLeader _unit;
-	if (primaryWeapon _unit != "") then { _unit selectWeapon primaryWeapon _unit };
-} else {
-	_unit setVariable ["GRLIB_can_speak", true, true];
-	_unit setSpeedMode (speedMode group player);
-	_unit doFollow player;
-};
+//Finally, lets get out units back to their waypoints before the ai group leader messed it up
+{
+    _x enableAI "FSM";
+    _x enableAI "PATH";
+    _wp = _unitWP get (hashValue _x);
+    if (!isNil "_wp" && {!(_wp isEqualTo [0,0,0])}) then {
+        if (round (_x distance2D _wp) < 100) then {
+            _x doMove _wp;
+        } else {
+            doStop _x;
+        };
+    };
+} forEach _units;


### PR DESCRIPTION
I made some changes to the par medic system to be less annoying for players, especially in sp who are controlling a group, but ai leader takes over and messes everything up (Taking gunners out of vehicles, etc)

I made some improvements including an improvement on the medic check while loop so the logic is more consistent

I changed the revive system to only stop auto calling an ai when the player is down, the player must choose to either ask to be revived or just respawn

I also made changes to the nearest medic system to try to avoid picking those who are in vehicles, and if they are in a vehicle, tries to pick those not in a turreted or gunner position (I keep getting annoyed when i get unconscious, and now my tank gunner that was convering fire jumps out and gets rekt)

I also ran an sqf formatting tool (Using a vs code extension) to bring some of the files to the ace 3 coding guidelines format