### PR TITLE
[i18n]Localize prompt messages

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,5 @@ mybuild/*
 core.liberation/build_info.sqf
 maps/Liberation_RX.Eusa/*
 maps/Liberation_RX.Utes/*
+/.vs
+/.gitignore

--- a/core.liberation/addons/FOB/def_fob.hpp
+++ b/core.liberation/addons/FOB/def_fob.hpp
@@ -29,7 +29,7 @@ class FOB_Defense {
 
 	class controls {
 		class Header: StdHeader {
-			text = "DEFENSE NAME";
+			text = "$STR_FOB_DEFENSE_NAME";
 			x = 0.198875 * safezoneW + safezoneX;
 			y = 0.1414 * safezoneH + safezoneY;
 			w = 0.1515 * safezoneW;
@@ -64,7 +64,7 @@ class FOB_Defense {
 
 		class SellButton : StdButton {
 			idc = 120;
-			text = "BUILD";
+			text = "$STR_FOB_BUILD";
 			action = "build_action = 1";
 			x = 0.2300 * safezoneW + safezoneX;
 			y = 0.7100 * safezoneH + safezoneY;
@@ -103,7 +103,7 @@ class FOB_Defense {
 			x = 0.58 * safezoneW + safezoneX;
 			y = ((BASE_Y + 0.32) * safezoneH) + safezoneY;
 			w = ((0.2 * safezoneW) / 5) - BORDERSIZE;
-			text = "OK";
+			text = "$STR_FOB_OK";
 			action = "input_save = ctrlText 527;";
 		};
 		class Input_ButtonName_Abort : StdButton {
@@ -111,7 +111,7 @@ class FOB_Defense {
 			x = 0.58 * safezoneW + safezoneX;
 			y = ((BASE_Y + 0.36) * safezoneH) + safezoneY;
 			w = ((0.2 * safezoneW) / 5) - BORDERSIZE;
-			text = "Cancel";
+			text = "$STR_FOB_CANCEL";
 			action = "input_save = 'null';";
 		};
 		class Input_TextField : StdButton {

--- a/core.liberation/addons/FOB/def_sector.hpp
+++ b/core.liberation/addons/FOB/def_sector.hpp
@@ -29,7 +29,7 @@ class Sector_Defense {
 
 	class controls {
 		class Header: StdHeader {
-			text = "SECTORS LIST";
+			text = "$STR_FOB_SECTORS_LIST";
 			x = 0.198875 * safezoneW + safezoneX;
 			y = 0.1414 * safezoneH + safezoneY;
 			w = 0.2340 * safezoneW;
@@ -64,7 +64,7 @@ class Sector_Defense {
 
 		class Button0 : StdButton {
 			idc = 120;
-			text = "OFF";
+			text = "$STR_FOB_OFF";
 			action = "build_type = 0; build_action = 1";
 			x = 0.3572 * safezoneW + safezoneX;
 			y = 0.2074 * safezoneH + safezoneY;
@@ -74,7 +74,7 @@ class Sector_Defense {
 
 		class Button1 : StdButton {
 			idc = 121;
-			text = "Light";
+			text = "$STR_FOB_LIGHT";
 			action = "build_type = 1; build_action = 1";
 			x = 0.3572 * safezoneW + safezoneX;
 			y = 0.2474 * safezoneH + safezoneY;
@@ -84,7 +84,7 @@ class Sector_Defense {
 
 		class Button2 : StdButton {
 			idc = 122;
-			text = "Medium";
+			text = "$STR_FOB_MEDIUM";
 			action = "build_type = 2; build_action = 1";
 			x = 0.3572 * safezoneW + safezoneX;
 			y = 0.2874 * safezoneH + safezoneY;
@@ -94,7 +94,7 @@ class Sector_Defense {
 
 		class Button3 : StdButton {
 			idc = 123;
-			text = "Heavy";
+			text = "$STR_FOB_HEAVY";
 			action = "build_type = 3; build_action = 1";
 			x = 0.3572 * safezoneW + safezoneX;
 			y = 0.3274 * safezoneH + safezoneY;
@@ -103,7 +103,7 @@ class Sector_Defense {
 		};
 
 		class ButtonExit : StdButton {
-			text = "Exit";
+			text = "$STR_FOB_EXIT";
 			action = "closeDialog 0";
 			x = 0.3572 * safezoneW + safezoneX;
 			y = 0.4474 * safezoneH + safezoneY;

--- a/core.liberation/addons/FOB/do_build_def.sqf
+++ b/core.liberation/addons/FOB/do_build_def.sqf
@@ -13,7 +13,7 @@ private _fob_dir = (getDir _fob_sign - 90);
 
 private _walls = count (_fob_pos nearObjects ["Wall_F", GRLIB_fob_range]);
 _walls = _walls + count (_fob_pos nearObjects ["HBarrier_base_F", GRLIB_fob_range]);
-if (_walls > 10) exitWith { hint "Cannot start Construction!\nToo many walls/sandbags nearby!" };
+if (_walls > 10) exitWith { hint localize "STR_FOB_CONSTRUCTION_TOO_MANY_WALLS" };
 
 createDialog "FOB_Defense";
 waitUntil { dialog };
@@ -55,7 +55,7 @@ while { dialog && alive player } do {
             waitUntil {uiSleep 0.3; ((input_save != "") || !(dialog) || !(alive player))};
             if ( input_save select [0,1] == "[" && input_save select [(count input_save)-1,(count input_save)] == "]") then {
                 _objects_to_build = (parseSimpleArray input_save);
-            } else { systemchat "Error: Invalid data!" };
+            } else { systemChat localize "STR_FOB_ERROR_INVALID_DATA" };
             { ctrlShow [_x, false] } foreach _input_controls;
         };
         closeDialog 0;
@@ -70,9 +70,9 @@ if (_count_objects == 0) exitWith {};
 if (!([parseNumber _defense_price] call F_pay)) exitWith {};
 
 build_confirmed = 1;
-private _msg = format ["%1 Build %2 (%3 objects) on FOB %4 ", name player, _defense_name, _count_objects, ([_fob_pos] call F_getFobName)];
+private _msg = format [localize "STR_FOB_BUILD_STATUS", name player, _defense_name, _count_objects, ([_fob_pos] call F_getFobName)];
 [gamelogic, _msg] remoteExec ["globalChat", 0];
-_msg = format ["Defense Template: %1\nCreated by: %2\nThanks to him !!", _defense_name, _template_creator];
+_msg = format [localize "STR_FOB_DEFENSE_TEMPLATE_INFO", _defense_name, _template_creator];
 [_msg] remoteExec ["hint", 0];
 
 // Build defense in FOB direction
@@ -81,7 +81,7 @@ _fob_pos set [2, 0];
 {
     if (_forEachIndex % 20 == 0) then {
         [player, "Land_Carrier_01_blast_deflector_up_sound"] remoteExec ["sound_range_remote_call", 2];
-        gamelogic globalChat format ["Construction in progress, %1 objects left...", (_count_objects - _forEachIndex)];
+        gamelogic globalChat format [localize "STR_FOB_CONSTRUCTION_IN_PROGRESS", (_count_objects - _forEachIndex)];
     };
 	_nextclass = (_x select 0);
 	_nextpos = (_x select 1);
@@ -99,9 +99,9 @@ _fob_pos set [2, 0];
         };
         sleep 0.1;
     };
-    if !(_nextclass in fob_defenses_classnames) then { diag_log format ["Defense Template: %1 - Rejected item: %2", _defense_name, _nextclass] };
+    if !(_nextclass in fob_defenses_classnames) then { diag_log format [localize "STR_FOB_DEFENSE_TEMPLATE_REJECTED", _defense_name, _nextclass] };
 } foreach _objects_to_build;
 
-gamelogic globalChat "Construction completed.";
+gamelogic globalChat localize "STR_FOB_CONSTRUCTION_COMPLETED";
 sleep 1;
 build_confirmed = 0;

--- a/core.liberation/addons/FOB/do_build_sector_def.sqf
+++ b/core.liberation/addons/FOB/do_build_sector_def.sqf
@@ -11,10 +11,10 @@ private _defense_list = ["None", "Light", "Medium", "Heavy"];
 private _max_defense = 6;
 
 private _butons_id = [120, 121, 122, 123];
-(_display displayCtrl 120) ctrlSetToolTip "Remove Defenses.";
-(_display displayCtrl 121) ctrlSetToolTip format ["Set Light Defenses for %1 Ammo.", GRLIB_defense_costs select 1];
-(_display displayCtrl 122) ctrlSetToolTip format ["Set Medium Defenses for %1 Ammo.", GRLIB_defense_costs select 2];
-(_display displayCtrl 123) ctrlSetToolTip format ["Set Heavy Defenses for %1 Ammo.", GRLIB_defense_costs select 3];
+(_display displayCtrl 120) ctrlSetToolTip localize "STR_FOB_REMOVE_GARRISON_TOOLTIP";
+(_display displayCtrl 121) ctrlSetToolTip format [localize "STR_FOB_SET_LIGHT_GARRISON", GRLIB_defense_costs select 1];
+(_display displayCtrl 122) ctrlSetToolTip format [localize "STR_FOB_SET_MEDIUM_GARRISON", GRLIB_defense_costs select 2];
+(_display displayCtrl 123) ctrlSetToolTip format [localize "STR_FOB_SET_HEAVY_GARRISON", GRLIB_defense_costs select 3];
 
 private _score = [player] call F_getScore;
 if (_score < GRLIB_perm_log) then {
@@ -66,14 +66,14 @@ while { dialog && alive player } do {
 
         if (build_type == 0) then {
             [_sector, 0] remoteExec ["sector_defenses_remote_call", 2];
-            gamelogic globalChat format ["You Remove Defenses from %1.", _sector_name];
+            gamelogic globalChat format [localize "STR_FOB_REMOVE_GARRISON_CONFIRM", _sector_name];
         } else {
             if (count GRLIB_sector_defense < _max_defense) then {
                 [_sector, build_type] remoteExec ["sector_defenses_remote_call", 2];
-                private _msg = format ["Player %1 Set %2 Defenses on %3.", name player, (_defense_list select build_type), _sector_name];
+                private _msg = format [localize "STR_FOB_PLAYER_SET_GARRISON", name player, (_defense_list select build_type), _sector_name];
                 [gamelogic, _msg] remoteExec ["globalChat", 0];
             } else {
-                gamelogic globalChat format ["You reach the Maximum Defenses limit (%1)!", _max_defense];
+                gamelogic globalChat format [localize "STR_FOB_MAX_GARRISON_REACHED", _max_defense];
             };
         };
         sleep 1;

--- a/core.liberation/addons/FOB/do_clean_def.sqf
+++ b/core.liberation/addons/FOB/do_clean_def.sqf
@@ -16,6 +16,6 @@ private _fob_pos = getPosATL _fob;
     sleep 0.05;
 } foreach (nearestObjects [_fob_pos, fob_defenses_classnames, GRLIB_fob_range]);
 
-gamelogic globalChat "Defenses Removed...";
+gamelogic globalChat localize "STR_FOB_DEFENSE_REMOVED";
 sleep 1;
 build_confirmed = 0;

--- a/core.liberation/addons/FOB/officer_init.sqf
+++ b/core.liberation/addons/FOB/officer_init.sqf
@@ -17,4 +17,4 @@ waituntil { sleep 1; !isNil "GRLIB_marker_init" };
 	};
 };
 waitUntil {!(isNull (findDisplay 46))};
-systemChat "-------- LRX FOB Initialized --------";
+systemChat localize "STR_FOB_INITIALIZED";

--- a/core.liberation/addons/JKB/JKB_dialog.hpp
+++ b/core.liberation/addons/JKB/JKB_dialog.hpp
@@ -125,7 +125,7 @@ class JKB_dialog {
  		};
 		class AutoplayCB: RscCheckbox {
 			idc = 233;
-			text = "$STR_JKB_AUTOPLAY";
+			text = $STR_JKB_AUTOPLAY;
 			x = (0.210 * safezoneW + safezoneX);
 			y = 0.3540 * safezoneH + safezoneY;
 			w = 0.0125 * safezoneW;
@@ -138,7 +138,7 @@ class JKB_dialog {
 		};
 		class AutoplayCBText: GREUH_RscStructuredText {
 			idc = -1;
-			text = "<t size='0.7'>$STR_JKB_AUTOPLAY</t>";
+			text = <t size='0.7'>$STR_JKB_AUTOPLAY</t>;
 			x = (0.226 * safezoneW + safezoneX);
 			y = 0.3540 * safezoneH + safezoneY;
 			w = 0.05 * safezoneW;
@@ -146,7 +146,7 @@ class JKB_dialog {
 		};
 		class RandomCB: RscCheckbox {
 			idc = 234;
-			text = "$STR_JKB_RANDOM";
+			text = $STR_JKB_RANDOM;
 			x = (0.300 * safezoneW + safezoneX);
 			y = 0.3540 * safezoneH + safezoneY;
 			w = 0.0125 * safezoneW;
@@ -159,7 +159,7 @@ class JKB_dialog {
 		};
 		class RandomCBText: GREUH_RscStructuredText	{
 			idc = -1;
-			text = "<t size='0.7'>$STR_JKB_RANDOM</t>";
+			text = <t size='0.7'>$STR_JKB_RANDOM</t>;
 			x = (0.316 * safezoneW + safezoneX);
 			y = 0.3540 * safezoneH + safezoneY;
 			w = 0.05 * safezoneW;
@@ -167,7 +167,7 @@ class JKB_dialog {
 		};
 		class StopButton: StdButton {
 			idc = -1;
-			text = "$STR_JKB_STOP";
+			text = $STR_JKB_STOP;
 			onButtonClick = "play_music = 2";
 			x = 0.2100 * safezoneW + safezoneX;
 			y = 0.386 * safezoneH + safezoneY;
@@ -177,7 +177,7 @@ class JKB_dialog {
 		};
 		class PlayButton: StdButton {
 			idc = -1;
-			text = "$STR_JKB_START";
+			text = $STR_JKB_START;
 			onButtonClick = "play_music = 1";
 			x = 0.3300 * safezoneW + safezoneX;
 			y = 0.386 * safezoneH + safezoneY;

--- a/core.liberation/addons/JKB/JKB_dialog.hpp
+++ b/core.liberation/addons/JKB/JKB_dialog.hpp
@@ -79,7 +79,7 @@ class JKB_dialog {
             align = "center";
 			colorText[] = {1, 1, 1};
 			size = "(((((safezoneW / safezoneH) min 1.2) / 1.2) / 25) * 1)";
-			text = "$STR_JKB_NOW_PLAYING";
+			text = "$STR_JKB_NOW_LISTENING";
  		};
         class VehText2: StdText {
 			idc = 230;
@@ -138,7 +138,7 @@ class JKB_dialog {
 		};
 		class AutoplayCBText: GREUH_RscStructuredText {
 			idc = -1;
-			text = <t size='0.7'>$STR_JKB_AUTOPLAY</t>;
+			text = $STR_JKB_AUTOPLAY;
 			x = (0.226 * safezoneW + safezoneX);
 			y = 0.3540 * safezoneH + safezoneY;
 			w = 0.05 * safezoneW;
@@ -159,7 +159,7 @@ class JKB_dialog {
 		};
 		class RandomCBText: GREUH_RscStructuredText	{
 			idc = -1;
-			text = <t size='0.7'>$STR_JKB_RANDOM</t>;
+			text = $STR_JKB_RANDOM;
 			x = (0.316 * safezoneW + safezoneX);
 			y = 0.3540 * safezoneH + safezoneY;
 			w = 0.05 * safezoneW;

--- a/core.liberation/addons/JKB/JKB_dialog.hpp
+++ b/core.liberation/addons/JKB/JKB_dialog.hpp
@@ -79,7 +79,7 @@ class JKB_dialog {
             align = "center";
 			colorText[] = {1, 1, 1};
 			size = "(((((safezoneW / safezoneH) min 1.2) / 1.2) / 25) * 1)";
-			text = "Now listening: ";
+			text = "$STR_JKB_NOW_PLAYING";
  		};
         class VehText2: StdText {
 			idc = 230;
@@ -110,7 +110,7 @@ class JKB_dialog {
             align = "center";
 			colorText[] = {1, 1, 1};
 			size = "(((((safezoneW / safezoneH) min 1.2) / 1.2) / 25) * 1)";
-			text = "Music in Jukebox: ";
+			text = "$STR_JKB_JUKEBOX_MUSIC";
  		};
         class VehText4: StdText {
 			idc = 232;
@@ -125,7 +125,7 @@ class JKB_dialog {
  		};
 		class AutoplayCB: RscCheckbox {
 			idc = 233;
-			text = "Auto play";
+			text = "$STR_JKB_AUTOPLAY";
 			x = (0.210 * safezoneW + safezoneX);
 			y = 0.3540 * safezoneH + safezoneY;
 			w = 0.0125 * safezoneW;
@@ -138,7 +138,7 @@ class JKB_dialog {
 		};
 		class AutoplayCBText: GREUH_RscStructuredText {
 			idc = -1;
-			text = "<t size='0.7'>Auto play</t>";
+			text = "<t size='0.7'>$STR_JKB_AUTOPLAY</t>";
 			x = (0.226 * safezoneW + safezoneX);
 			y = 0.3540 * safezoneH + safezoneY;
 			w = 0.05 * safezoneW;
@@ -146,7 +146,7 @@ class JKB_dialog {
 		};
 		class RandomCB: RscCheckbox {
 			idc = 234;
-			text = "Random";
+			text = "$STR_JKB_RANDOM";
 			x = (0.300 * safezoneW + safezoneX);
 			y = 0.3540 * safezoneH + safezoneY;
 			w = 0.0125 * safezoneW;
@@ -159,7 +159,7 @@ class JKB_dialog {
 		};
 		class RandomCBText: GREUH_RscStructuredText	{
 			idc = -1;
-			text = "<t size='0.7'>Random</t>";
+			text = "<t size='0.7'>$STR_JKB_RANDOM</t>";
 			x = (0.316 * safezoneW + safezoneX);
 			y = 0.3540 * safezoneH + safezoneY;
 			w = 0.05 * safezoneW;
@@ -167,7 +167,7 @@ class JKB_dialog {
 		};
 		class StopButton: StdButton {
 			idc = -1;
-			text = $STR_JKB_STOP;
+			text = "$STR_JKB_STOP";
 			onButtonClick = "play_music = 2";
 			x = 0.2100 * safezoneW + safezoneX;
 			y = 0.386 * safezoneH + safezoneY;
@@ -177,7 +177,7 @@ class JKB_dialog {
 		};
 		class PlayButton: StdButton {
 			idc = -1;
-			text = $STR_JKB_START;
+			text = "$STR_JKB_START";
 			onButtonClick = "play_music = 1";
 			x = 0.3300 * safezoneW + safezoneX;
 			y = 0.386 * safezoneH + safezoneY;

--- a/core.liberation/addons/JKB/JKB_init.sqf
+++ b/core.liberation/addons/JKB/JKB_init.sqf
@@ -83,11 +83,11 @@ addMusicEventHandler ["MusicStop", {
 		} else {
 			playMusic _classname;
 		};
-		hintSilent format ["Now Playing:\n%1", JKB_current_music splitString "-" select 0];
+		hintSilent format [localize "STR_JKB_NOW_PLAYING", JKB_current_music splitString "-" select 0];
 	} else {
 		[JKB_current_sound] spawn JKB_stopMusic;
 	};
 }];
 
 waitUntil {!(isNull (findDisplay 46))};
-systemChat "-------- Juke Box Initialized --------";
+systemChat localize "STR_JKB_JUKEBOX_INITIALIZED";

--- a/core.liberation/addons/JKB/fn_openJukeBox.sqf
+++ b/core.liberation/addons/JKB/fn_openJukeBox.sqf
@@ -40,7 +40,7 @@ if(!isNull (findDisplay 2306)) then {
 			};
 			JKB_current_music = _title;
 			JKB_last_music = _selected;
-			hintSilent format ["Now Playing:\n%1", JKB_current_music splitString "-" select 0];
+			hintSilent format [localize "STR_JKB_NOW_PLAYING", JKB_current_music splitString "-" select 0];
 			play_music = 0;
 		};
 

--- a/core.liberation/addons/KEY/shortcut_init.sqf
+++ b/core.liberation/addons/KEY/shortcut_init.sqf
@@ -39,7 +39,7 @@ waitUntil {sleep 0.5;!(isNull (findDisplay 46))};
 		} else {
 			showHUD [true,true,true,true,true,true,true,true,true,true];
 		};
-		gamelogic globalChat format ["HUD Toggle %1.", _state];
+		gamelogic globalChat format [localize "STR_KEY_HUD_TOGGLE", _state];
 	};
 }];
 
@@ -48,7 +48,7 @@ waitUntil {sleep 0.5;!(isNull (findDisplay 46))};
 	if (_this select 1 == (actionKeys 'User15') select 0) then {
 		_name = format ["%1_%2_%3-%4_%5.png", name player, worldname, date select 3, date select 4, round(time)];
 		screenshot _name;
-		gamelogic globalChat format ["Take screenshot: %1.", _name];
+		gamelogic globalChat format [localize "STR_KEY_TAKE_SCREENSHOT", _name];
 	};
 }];
 
@@ -59,7 +59,7 @@ if (GRLIB_Player_VIP) then {
 			_save = 0;  // Dump savegame: 0 = no, 1 = yes
 			[_save] execVM "scripts\shared\diag_debug.sqf";
 			[_save, "scripts\shared\diag_debug.sqf"] remoteExec ["execVM", 2];
-			gamelogic globalChat "LRX Diag called.";
+			gamelogic globalChat localize "STR_KEY_LRX_DIAG_CALLED";
 		};
 	}];
 };

--- a/core.liberation/stringtable.xml
+++ b/core.liberation/stringtable.xml
@@ -8556,7 +8556,7 @@
 			<Czech>Počkám zde, až se vrátíte s %1, prosím, pospěšte si!</Czech>
 		</Key>
 	</Package>
-
+	
 	<!-- pSiKO Earplugs -->
 	<Package name="NREEarplugs">
 		<Key ID="STR_NREEP_IN_HINT">
@@ -8609,6 +8609,202 @@
 		</Key>
 	</Package>
 
+	<!-- pSiKO FOB -->
+	<Package name="LRX_FOB">
+		<Key ID="STR_FOB_CONSTRUCTION_TOO_MANY_WALLS">
+			<Original>Cannot start Construction!\nToo many walls/sandbags nearby!</Original>
+			<French>Impossible de commencer la construction !\nTrop de murs ou sacs de sable à proximité !</French>
+			<German>Baubeginn nicht möglich!\nZu viele Wände oder Sandsäcke in der Nähe!</German>
+			<Spanish>¡No se puede iniciar la construcción!\n¡Demasiadas paredes o sacos de arena cerca!</Spanish>
+			<Russian>Невозможно начать строительство!\nСлишком много стен или мешков с песком поблизости!</Russian>
+			<Chinesesimp>无法开始建造！\n附近有太多墙体或沙袋！</Chinesesimp>
+			<Chinese>無法開始建造！\n附近有太多牆體或沙袋！</Chinese>
+			<Japanese>建設を開始できません！\n近くに壁や土嚢が多すぎます！</Japanese>
+			<Portuguese>Não é possível iniciar a construção!\nMuitos muros ou sacos de areia por perto!</Portuguese>
+			<Czech>Nelze zahájit stavbu!\nPříliš mnoho zdí nebo pytlů s pískem v okolí!</Czech>
+		</Key>
+		<Key ID="STR_FOB_ERROR_INVALID_DATA">
+			<Original>Error: Invalid data!</Original>
+			<French>Erreur : Données invalides !</French>
+			<German>Fehler: Ungültige Daten!</German>
+			<Spanish>Error: ¡Datos no válidos!</Spanish>
+			<Russian>Ошибка: Недопустимые данные!</Russian>
+			<Chinesesimp>错误：数据无效！</Chinesesimp>
+			<Chinese>錯誤：資料無效！</Chinese>
+			<Japanese>エラー：無効なデータ！</Japanese>
+			<Portuguese>Erro: Dados inválidos!</Portuguese>
+			<Czech>Chyba: Neplatná data!</Czech>
+		</Key>
+		<Key ID="STR_FOB_BUILD_STATUS">
+			<Original>%1 Build %2 (%3 objects) on FOB %4</Original>
+			<French>%1 a construit %2 (composé de %3 éléments) sur la FOB %4</French>
+			<German>%1 errichtet %2 (insgesamt %3 Objekte) auf FOB %4</German>
+			<Spanish>%1 ha construido %2 (con %3 objetos) en la FOB %4</Spanish>
+			<Russian>%1 построил %2 (в количестве %3 объектов) на базе FOB %4</Russian>
+			<Chinesesimp>%1 在前线基地 %4 建造了 %2（共 %3 个部件）</Chinesesimp>
+			<Chinese>%1 在前線基地 %4 建造了 %2（共 %3 個部件）</Chinese>
+			<Japanese>%1 が FOB %4 に %2（全%3個のオブジェクト）を建設しました</Japanese>
+			<Portuguese>%1 construiu %2 (com %3 itens) na base avançada %4</Portuguese>
+			<Czech>%1 postavil %2 (celkem %3 objektů) na základně FOB %4</Czech>
+		</Key>
+		<Key ID="STR_FOB_DEFENSE_TEMPLATE_INFO">
+			<Original>Defense Template: %1\nCreated by: %2\nThanks to him !!</Original>
+			<French>Modèle de défense : %1\nCréé par : %2\nMerci à lui !!</French>
+			<German>Verteidigungsvorlage: %1\nErstellt von: %2\nVielen Dank an ihn!!</German>
+			<Spanish>Plantilla de defensa: %1\nCreada por: %2\n¡Gracias a él!</Spanish>
+			<Russian>Шаблон обороны: %1\nСоздан: %2\nСпасибо ему!!</Russian>
+			<Chinesesimp>防御模板：%1\n创建者：%2\n感谢他的贡献！</Chinesesimp>
+			<Chinese>防禦模板：%1\n創建者：%2\n感謝他的貢獻！</Chinese>
+			<Japanese>防衛テンプレート: %1\n作成者: %2\n彼に感謝！！</Japanese>
+			<Portuguese>Modelo de defesa: %1\nCriado por: %2\nObrigado a ele!!</Portuguese>
+			<Czech>Obranná šablona: %1\nVytvořil: %2\nDíky němu!!</Czech>
+		</Key>
+		<Key ID="STR_FOB_CONSTRUCTION_IN_PROGRESS">
+			<Original>Construction in progress, %1 objects left...</Original>
+			<French>Construction en cours, il reste %1 objets...</French>
+			<German>Bau läuft, noch %1 Objekte übrig...</German>
+			<Spanish>Construcción en curso, quedan %1 objetos...</Spanish>
+			<Russian>Идёт строительство, осталось %1 объектов...</Russian>
+			<Chinesesimp>建造进行中，剩余 %1 个部件...</Chinesesimp>
+			<Chinese>建造進行中，剩餘 %1 個部件...</Chinese>
+			<Japanese>建設中、残り %1 個のオブジェクト...</Japanese>
+			<Portuguese>Construção em andamento, faltam %1 objetos...</Portuguese>
+			<Czech>Stavba probíhá, zbývá %1 objektů...</Czech>
+		</Key>
+		<Key ID="STR_FOB_DEFENSE_TEMPLATE_REJECTED">
+			<Original>Defense Template: %1 - Rejected item: %2</Original>
+			<French>Modèle de défense : %1 - Élément refusé : %2</French>
+			<German>Verteidigungsvorlage: %1 - Abgelehntes Objekt: %2</German>
+			<Spanish>Plantilla de defensa: %1 - Objeto rechazado: %2</Spanish>
+			<Russian>Шаблон обороны: %1 — Отклонённый объект: %2</Russian>
+			<Chinesesimp>防御模板：%1 - 被拒绝的对象：%2</Chinesesimp>
+			<Chinese>防禦模板：%1 - 被拒絕的對象：%2</Chinese>
+			<Japanese>防衛テンプレート: %1 - 却下された項目: %2</Japanese>
+			<Portuguese>Modelo de defesa: %1 - Item rejeitado: %2</Portuguese>
+			<Czech>Obranná šablona: %1 - Zamítnutý objekt: %2</Czech>
+		</Key>
+		<Key ID="STR_FOB_CONSTRUCTION_COMPLETED">
+			<Original>Construction completed.</Original>
+			<French>Construction terminée.</French>
+			<German>Bau abgeschlossen.</German>
+			<Spanish>Construcción completada.</Spanish>
+			<Russian>Строительство завершено.</Russian>
+			<Chinesesimp>建造完成。</Chinesesimp>
+			<Chinese>建造完成。</Chinese>
+			<Japanese>建設完了。</Japanese>
+			<Portuguese>Construção concluída.</Portuguese>
+			<Czech>Stavba dokončena.</Czech>
+		</Key>
+		<Key ID="STR_FOB_REMOVE_GARRISON_TOOLTIP">
+			<Original>Remove Defenses.</Original>
+			<French>Retirer la garnison.</French>
+			<German>Garnison entfernen.</German>
+			<Spanish>Retirar la guarnición.</Spanish>
+			<Russian>Убрать гарнизон.</Russian>
+			<Chinesesimp>移除守军。</Chinesesimp>
+			<Chinese>移除守軍。</Chinese>
+			<Japanese>守備隊を撤去する。</Japanese>
+			<Portuguese>Remover guarnição.</Portuguese>
+			<Czech>Odebrat posádku.</Czech>
+		</Key>
+		<Key ID="STR_FOB_SET_LIGHT_GARRISON">
+			<Original>Set Light Defenses for %1 Ammo.</Original>
+			<French>Déployer une petite garnison pour %1 munitions.</French>
+			<German>Leichte Garnison für %1 Munition einsetzen.</German>
+			<Spanish>Asignar una guarnición ligera por %1 munición.</Spanish>
+			<Russian>Выставить лёгкий гарнизон за %1 боеприпасов.</Russian>
+			<Chinesesimp>部署轻型守军，消耗 %1 弹药。</Chinesesimp>
+			<Chinese>部署輕型守軍，消耗 %1 彈藥。</Chinese>
+			<Japanese>%1 弾薬で軽守備隊を配置。</Japanese>
+			<Portuguese>Designar uma guarnição leve por %1 de munição.</Portuguese>
+			<Czech>Nasadit lehkou posádku za %1 munice.</Czech>
+		</Key>
+		<Key ID="STR_FOB_SET_MEDIUM_GARRISON">
+			<Original>Set Medium Defenses for %1 Ammo.</Original>
+			<French>Déployer une garnison moyenne pour %1 munitions.</French>
+			<German>Mittlere Garnison für %1 Munition einsetzen.</German>
+			<Spanish>Asignar una guarnición media por %1 munición.</Spanish>
+			<Russian>Выставить средний гарнизон за %1 боеприпасов.</Russian>
+			<Chinesesimp>部署中型守军，消耗 %1 弹药。</Chinesesimp>
+			<Chinese>部署中型守軍，消耗 %1 彈藥。</Chinese>
+			<Japanese>%1 弾薬で中型守備隊を配置。</Japanese>
+			<Portuguese>Designar uma guarnição média por %1 de munição.</Portuguese>
+			<Czech>Nasadit střední posádku za %1 munice.</Czech>
+		</Key>
+		<Key ID="STR_FOB_SET_HEAVY_GARRISON">
+			<Original>Set Heavy Defenses for %1 Ammo.</Original>
+			<French>Déployer une garnison lourde pour %1 munitions.</French>
+			<German>Schwere Garnison für %1 Munition einsetzen.</German>
+			<Spanish>Asignar una guarnición pesada por %1 munición.</Spanish>
+			<Russian>Выставить тяжёлый гарнизон за %1 боеприпасов.</Russian>
+			<Chinesesimp>部署重型守军，消耗 %1 弹药。</Chinesesimp>
+			<Chinese>部署重型守軍，消耗 %1 彈藥。</Chinese>
+			<Japanese>%1 弾薬で重守備隊を配置。</Japanese>
+			<Portuguese>Designar uma guarnição pesada por %1 de munição.</Portuguese>
+			<Czech>Nasadit těžkou posádku za %1 munice.</Czech>
+		</Key>
+		<Key ID="STR_FOB_REMOVE_GARRISON_CONFIRM">
+			<Original>You Remove Defenses from %1.</Original>
+			<French>Vous avez retiré la garnison de %1.</French>
+			<German>Du hast die Garnison aus %1 entfernt.</German>
+			<Spanish>Has retirado la guarnición de %1.</Spanish>
+			<Russian>Вы убрали гарнизон из %1.</Russian>
+			<Chinesesimp>你已从 %1 移除守军。</Chinesesimp>
+			<Chinese>你已從 %1 移除守軍。</Chinese>
+			<Japanese>%1 から守備隊を撤去しました。</Japanese>
+			<Portuguese>Você removeu a guarnição de %1.</Portuguese>
+			<Czech>Odstranil jsi posádku z %1.</Czech>
+		</Key>
+		<Key ID="STR_FOB_PLAYER_SET_GARRISON">
+			<Original>Player %1 Set %2 Defenses on %3.</Original>
+			<French>Le joueur %1 a déployé une garnison %2 sur %3.</French>
+			<German>Spieler %1 hat %2 Garnison auf %3 eingesetzt.</German>
+			<Spanish>El jugador %1 asignó una guarnición %2 en %3.</Spanish>
+			<Russian>Игрок %1 разместил гарнизон %2 на %3.</Russian>
+			<Chinesesimp>玩家 %1 在 %3 部署了 %2 守军。</Chinesesimp>
+			<Chinese>玩家 %1 在 %3 部署了 %2 守軍。</Chinese>
+			<Japanese>プレイヤー %1 が %3 に %2 守備隊を配置しました。</Japanese>
+			<Portuguese>O jogador %1 designou uma guarnição %2 em %3.</Portuguese>
+			<Czech>Hráč %1 umístil %2 posádku na %3.</Czech>
+		</Key>
+		<Key ID="STR_FOB_MAX_GARRISON_REACHED">
+			<Original>You reach the Maximum Defenses limit (%1)!</Original>
+			<French>Vous avez atteint la limite maximale de garnison (%1) !</French>
+			<German>Du hast das maximale Garnisonslimit erreicht (%1)!</German>
+			<Spanish>¡Has alcanzado el límite máximo de guarniciones (%1)!</Spanish>
+			<Russian>Достигнут лимит гарнизона (%1)!</Russian>
+			<Chinesesimp>你已达到最大守军数量限制（%1）！</Chinesesimp>
+			<Chinese>你已達到最大守軍數量限制（%1）！</Chinese>
+			<Japanese>守備隊の最大数制限（%1）に達しました！</Japanese>
+			<Portuguese>Você atingiu o limite máximo de guarnições (%1)!</Portuguese>
+			<Czech>Dosáhl jsi maximálního limitu posádky (%1)!</Czech>
+		</Key>
+		<Key ID="STR_FOB_DEFENSE_REMOVED">
+			<Original>Defenses Removed...</Original>
+			<French>Défenses supprimées...</French>
+			<German>Verteidigungen entfernt...</German>
+			<Spanish>Defensas eliminadas...</Spanish>
+			<Russian>Укрепления удалены...</Russian>
+			<Chinesesimp>防御工事已拆除……</Chinesesimp>
+			<Chinese>防禦工事已拆除……</Chinese>
+			<Japanese>防御設備を撤去しました...</Japanese>
+			<Portuguese>Defesas removidas...</Portuguese>
+			<Czech>Obrana odstraněna...</Czech>
+		</Key>
+		<Key ID="STR_FOB_INITIALIZED">
+			<Original>-------- LRX FOB Initialized --------</Original>
+			<French>-------- LRX FOB initialisée --------</French>
+			<German>-------- LRX FOB initialisiert --------</German>
+			<Spanish>-------- LRX FOB iniciada --------</Spanish>
+			<Russian>-------- LRX FOB запущена --------</Russian>
+			<Chinesesimp>-------- LRX FOB 已初始化 --------</Chinesesimp>
+			<Chinese>-------- LRX FOB 已初始化 --------</Chinese>
+			<Japanese>-------- LRX FOB が起動しました --------</Japanese>
+			<Portuguese>-------- LRX FOB inicializada --------</Portuguese>
+			<Czech>-------- LRX FOB inicializována --------</Czech>
+		</Key>
+	</Package>
+	
 	<!-- pSiKO AI Revive -->
 	<Package name="LRX_PAR">
 		<Key ID="STR_PAR_Need_Medic1">

--- a/core.liberation/stringtable.xml
+++ b/core.liberation/stringtable.xml
@@ -8803,6 +8803,126 @@
 			<Portuguese>-------- LRX FOB inicializada --------</Portuguese>
 			<Czech>-------- LRX FOB inicializována --------</Czech>
 		</Key>
+		<Key ID="STR_FOB_DEFENSE_NAME">
+			<Original>DEFENSE NAME</Original>
+			<French>Nom de la défense</French>
+			<German>Verteidigungsname</German>
+			<Spanish>Nombre de defensa</Spanish>
+			<Russian>Название обороны</Russian>
+			<Chinesesimp>防御名称</Chinesesimp>
+			<Chinese>防禦名稱</Chinese>
+			<Japanese>防衛名</Japanese>
+			<Portuguese>Nome da defesa</Portuguese>
+			<Czech>Název obrany</Czech>
+		</Key>
+		<Key ID="STR_FOB_BUILD">
+			<Original>BUILD</Original>
+			<French>CONSTRUIRE</French>
+			<German>BAUEN</German>
+			<Spanish>CONSTRUIR</Spanish>
+			<Russian>ПОСТРОИТЬ</Russian>
+			<Chinesesimp>建造</Chinesesimp>
+			<Chinese>建造</Chinese>
+			<Japanese>建設</Japanese>
+			<Portuguese>CONSTRUIR</Portuguese>
+			<Czech>Postavit</Czech>
+		</Key>
+		<Key ID="STR_FOB_OK">
+			<Original>OK</Original>
+			<French>OK</French>
+			<German>OK</German>
+			<Spanish>OK</Spanish>
+			<Russian>ОК</Russian>
+			<Chinesesimp>确定</Chinesesimp>
+			<Chinese>確定</Chinese>
+			<Japanese>OK</Japanese>
+			<Portuguese>OK</Portuguese>
+			<Czech>OK</Czech>
+		</Key>
+		<Key ID="STR_FOB_CANCEL">
+			<Original>Cancel</Original>
+			<French>Annuler</French>
+			<German>Abbrechen</German>
+			<Spanish>Cancelar</Spanish>
+			<Russian>Отмена</Russian>
+			<Chinesesimp>取消</Chinesesimp>
+			<Chinese>取消</Chinese>
+			<Japanese>キャンセル</Japanese>
+			<Portuguese>Cancelar</Portuguese>
+			<Czech>Zrušit</Czech>
+		</Key>
+		<Key ID="STR_FOB_SECTORS_LIST">
+			<Original>SECTORS LIST</Original>
+			<French>LISTE DES SECTEURS</French>
+			<German>Sektor-Liste</German>
+			<Spanish>Lista de sectores</Spanish>
+			<Russian>Список секторов</Russian>
+			<Chinesesimp>区域列表</Chinesesimp>
+			<Chinese>區域列表</Chinese>
+			<Japanese>セクター一覧</Japanese>
+			<Portuguese>Lista de Setores</Portuguese>
+			<Czech>Seznam sektorů</Czech>
+		</Key>
+		<Key ID="STR_FOB_OFF">
+			<Original>OFF</Original>
+			<French>OFF</French>
+			<German>Aus</German>
+			<Spanish>Apagado</Spanish>
+			<Russian>Выкл</Russian>
+			<Chinesesimp>关闭</Chinesesimp>
+			<Chinese>關閉</Chinese>
+			<Japanese>オフ</Japanese>
+			<Portuguese>Desligado</Portuguese>
+			<Czech>Vypnuto</Czech>
+		</Key>
+		<Key ID="STR_FOB_LIGHT">
+			<Original>Light</Original>
+			<French>Léger</French>
+			<German>Leicht</German>
+			<Spanish>Ligero</Spanish>
+			<Russian>Лёгкий</Russian>
+			<Chinesesimp>轻型</Chinesesimp>
+			<Chinese>輕型</Chinese>
+			<Japanese>軽量</Japanese>
+			<Portuguese>Leve</Portuguese>
+			<Czech>Lehký</Czech>
+		</Key>
+		<Key ID="STR_FOB_MEDIUM">
+			<Original>Medium</Original>
+			<French>Moyen</French>
+			<German>Mittel</German>
+			<Spanish>Medio</Spanish>
+			<Russian>Средний</Russian>
+			<Chinesesimp>中型</Chinesesimp>
+			<Chinese>中型</Chinese>
+			<Japanese>中型</Japanese>
+			<Portuguese>Médio</Portuguese>
+			<Czech>Střední</Czech>
+		</Key>
+		<Key ID="STR_FOB_HEAVY">
+			<Original>Heavy</Original>
+			<French>Lourd</French>
+			<German>Schwer</German>
+			<Spanish>Pesado</Spanish>
+			<Russian>Тяжёлый</Russian>
+			<Chinesesimp>重型</Chinesesimp>
+			<Chinese>重型</Chinese>
+			<Japanese>重量</Japanese>
+			<Portuguese>Pesado</Portuguese>
+			<Czech>Těžký</Czech>
+		</Key>
+		<Key ID="STR_FOB_EXIT">
+			<Original>Exit</Original>
+			<French>Quitter</French>
+			<German>Beenden</German>
+			<Spanish>Salir</Spanish>
+			<Russian>Выход</Russian>
+			<Chinesesimp>退出</Chinesesimp>
+			<Chinese>退出</Chinese>
+			<Japanese>終了</Japanese>
+			<Portuguese>Sair</Portuguese>
+			<Czech>Ukončit</Czech>
+		</Key>
 	</Package>
 	
 	<!-- pSiKO JKB -->

--- a/core.liberation/stringtable.xml
+++ b/core.liberation/stringtable.xml
@@ -7189,40 +7189,6 @@
 			<Czech>Přemalovat</Czech>
 		</Key>
 
-		<!-- JKB_dialog -->
-		<Key ID="STR_JKB_MENU">
-			<Original>-- Juke Box --</Original>
-			<Russian>-- Музыка</Russian>
-			<Chinesesimp>-- 音乐播放器 --</Chinesesimp>
-			<Chinese>-- 音樂播放器 --</Chinese>
-			<Portuguese>-- Juke Box --</Portuguese>
-			<Czech>-- Juke Box --</Czech>
-		</Key>
-		<Key ID="STR_JKB_ACTION">
-			<Original>Open JukeBox</Original>
-			<Russian>Открыть Музыку</Russian>
-			<Chinesesimp>打开音乐播放器</Chinesesimp>
-			<Chinese>打開音樂播放器</Chinese>
-			<Portuguese>Abrir Juke Box</Portuguese>
-			<Czech>Otevřete JukeBox</Czech>
-		</Key>
-		<Key ID="STR_JKB_START">
-			<Original>Play</Original>
-			<Russian>Play</Russian>
-			<Chinesesimp>播放</Chinesesimp>
-			<Chinese>播放</Chinese>
-			<Portuguese>Jogar</Portuguese>
-			<Czech>Play</Czech>
-		</Key>
-		<Key ID="STR_JKB_STOP">
-			<Original>Stop</Original>
-			<Russian>Stop</Russian>
-			<Chinesesimp>暂停</Chinesesimp>
-			<Chinese>暫停</Chinese>
-			<Portuguese>Pare</Portuguese>
-			<Czech>Stop</Czech>
-		</Key>
-
 		<!-- liberation_airdrop.hpp -->
 		<Key ID="STR_AIRDROP_CANCEL">
 			<Original>Cancel</Original>
@@ -8945,11 +8911,79 @@
 			<German>-------- Jukebox initialisiert --------</German>
 			<Spanish>-------- Juke Box iniciada --------</Spanish>
 			<Russian>-------- Джукбокс запущен --------</Russian>
-			<Chinesesimp>-------- 点唱机已初始化 --------</Chinesesimp>
-			<Chinese>-------- 點唱機已初始化 --------</Chinese>
+			<Chinesesimp>-------- 音乐播放器已初始化 --------</Chinesesimp>
+			<Chinese>-------- 音樂播放器已初始化 --------</Chinese>
 			<Japanese>-------- ジュークボックスが起動しました --------</Japanese>
 			<Portuguese>-------- Juke Box inicializado --------</Portuguese>
 			<Czech>-------- Jukebox inicializován --------</Czech>
+		</Key>
+		<Key ID="STR_JKB_JUKEBOX_MUSIC">
+			<Original>Music in Jukebox: </Original>
+			<French>Musique dans le Jukebox : </French>
+			<German>Musik in der Jukebox: </German>
+			<Spanish>Música en la Jukebox: </Spanish>
+			<Russian>Музыка в джукбоксе: </Russian>
+			<Chinesesimp>音乐播放器音乐：</Chinesesimp>
+			<Chinese>音樂播放器音樂：</Chinese>
+			<Japanese>ジュークボックスの音楽：</Japanese>
+			<Portuguese>Música na Jukebox: </Portuguese>
+			<Czech>Hudba v jukeboxu: </Czech>
+		</Key>
+		<Key ID="STR_JKB_AUTOPLAY">
+			<Original>Auto play</Original>
+			<French>Lecture automatique</French>
+			<German>Automatisch abspielen</German>
+			<Spanish>Reproducción automática</Spanish>
+			<Russian>Автовоспроизведение</Russian>
+			<Chinesesimp>自动播放</Chinesesimp>
+			<Chinese>自動播放</Chinese>
+			<Japanese>自動再生</Japanese>
+			<Portuguese>Reprodução automática</Portuguese>
+			<Czech>Automatické přehrávání</Czech>
+		</Key>
+		<Key ID="STR_JKB_RANDOM">
+			<Original>Random</Original>
+			<French>Aléatoire</French>
+			<German>Zufällig</German>
+			<Spanish>Aleatorio</Spanish>
+			<Russian>Случайный</Russian>
+			<Chinesesimp>随机播放</Chinesesimp>
+			<Chinese>隨機播放</Chinese>
+			<Japanese>ランダム</Japanese>
+			<Portuguese>Aleatório</Portuguese>
+			<Czech>Náhodně</Czech>
+		</Key>
+		<Key ID="STR_JKB_MENU">
+			<Original>-- Juke Box --</Original>
+			<Russian>-- Музыка</Russian>
+			<Chinesesimp>-- 音乐播放器 --</Chinesesimp>
+			<Chinese>-- 音樂播放器 --</Chinese>
+			<Portuguese>-- Juke Box --</Portuguese>
+			<Czech>-- Juke Box --</Czech>
+		</Key>
+		<Key ID="STR_JKB_ACTION">
+			<Original>Open JukeBox</Original>
+			<Russian>Открыть Музыку</Russian>
+			<Chinesesimp>打开音乐播放器</Chinesesimp>
+			<Chinese>打開音樂播放器</Chinese>
+			<Portuguese>Abrir Juke Box</Portuguese>
+			<Czech>Otevřete JukeBox</Czech>
+		</Key>
+		<Key ID="STR_JKB_START">
+			<Original>Play</Original>
+			<Russian>Play</Russian>
+			<Chinesesimp>播放</Chinesesimp>
+			<Chinese>播放</Chinese>
+			<Portuguese>Jogar</Portuguese>
+			<Czech>Play</Czech>
+		</Key>
+		<Key ID="STR_JKB_STOP">
+			<Original>Stop</Original>
+			<Russian>Stop</Russian>
+			<Chinesesimp>暂停</Chinesesimp>
+			<Chinese>暫停</Chinese>
+			<Portuguese>Pare</Portuguese>
+			<Czech>Stop</Czech>
 		</Key>
 	</Package>
 

--- a/core.liberation/stringtable.xml
+++ b/core.liberation/stringtable.xml
@@ -8805,6 +8805,36 @@
 		</Key>
 	</Package>
 	
+	<!-- pSiKO JKB -->
+	<Package name="LRX_JKB">
+		<Key ID="STR_JKB_NOW_PLAYING">
+			<Original>Now Playing:\n%1</Original>
+			<French>Lecture en cours :\n%1</French>
+			<German>Jetzt läuft:\n%1</German>
+			<Spanish>Reproduciendo:\n%1</Spanish>
+			<Russian>Сейчас играет:\n%1</Russian>
+			<Chinesesimp>正在播放：\n%1</Chinesesimp>
+			<Chinese>正在播放：\n%1</Chinese>
+			<Japanese>再生中：\n%1</Japanese>
+			<Portuguese>Tocando agora:\n%1</Portuguese>
+			<Czech>Nyní hraje:\n%1</Czech>
+		</Key>
+		<Key ID="STR_JKB_JUKEBOX_INITIALIZED">
+			<Original>-------- Juke Box Initialized --------</Original>
+			<French>-------- Juke-box initialisé --------</French>
+			<German>-------- Jukebox initialisiert --------</German>
+			<Spanish>-------- Juke Box iniciada --------</Spanish>
+			<Russian>-------- Джукбокс запущен --------</Russian>
+			<Chinesesimp>-------- 点唱机已初始化 --------</Chinesesimp>
+			<Chinese>-------- 點唱機已初始化 --------</Chinese>
+			<Japanese>-------- ジュークボックスが起動しました --------</Japanese>
+			<Portuguese>-------- Juke Box inicializado --------</Portuguese>
+			<Czech>-------- Jukebox inicializován --------</Czech>
+		</Key>
+
+
+	</Package>
+	
 	<!-- pSiKO AI Revive -->
 	<Package name="LRX_PAR">
 		<Key ID="STR_PAR_Need_Medic1">

--- a/core.liberation/stringtable.xml
+++ b/core.liberation/stringtable.xml
@@ -8905,6 +8905,18 @@
 			<Portuguese>Tocando agora:\n%1</Portuguese>
 			<Czech>Nyní hraje:\n%1</Czech>
 		</Key>
+		<Key ID="STR_JKB_NOW_LISTENING">
+			<Original>Now Playing:</Original>
+			<French>Lecture en cours :</French>
+			<German>Jetzt läuft:</German>
+			<Spanish>Reproduciendo:</Spanish>
+			<Russian>Сейчас играет:</Russian>
+			<Chinesesimp>正在播放：</Chinesesimp>
+			<Chinese>正在播放：</Chinese>
+			<Japanese>再生中：</Japanese>
+			<Portuguese>Tocando agora:</Portuguese>
+			<Czech>Nyní hraje:</Czech>
+		</Key>
 		<Key ID="STR_JKB_JUKEBOX_INITIALIZED">
 			<Original>-------- Juke Box Initialized --------</Original>
 			<French>-------- Juke-box initialisé --------</French>

--- a/core.liberation/stringtable.xml
+++ b/core.liberation/stringtable.xml
@@ -8831,8 +8831,46 @@
 			<Portuguese>-------- Juke Box inicializado --------</Portuguese>
 			<Czech>-------- Jukebox inicializován --------</Czech>
 		</Key>
+	</Package>
 
-
+	<!-- pSiKO KEY -->
+	<Package name="LRX_KEY">
+		<Key ID="STR_KEY_HUD_TOGGLE">
+			<Original>HUD Toggle %1.</Original>
+			<French>Affichage tête haute : %1.</French>
+			<German>HUD umgeschaltet: %1.</German>
+			<Spanish>HUD cambiado: %1.</Spanish>
+			<Russian>Интерфейс переключен: %1.</Russian>
+			<Chinesesimp>HUD 已切换：%1。</Chinesesimp>
+			<Chinese>HUD 已切換：%1。</Chinese>
+			<Japanese>HUD を切り替えました: %1。</Japanese>
+			<Portuguese>HUD alternado: %1.</Portuguese>
+			<Czech>HUD přepnuto: %1.</Czech>
+		</Key>
+		<Key ID="STR_KEY_TAKE_SCREENSHOT">
+			<Original>Take screenshot: %1.</Original>
+			<French>Capture d'écran : %1.</French>
+			<German>Screenshot aufgenommen: %1.</German>
+			<Spanish>Captura de pantalla: %1.</Spanish>
+			<Russian>Скриншот сделан: %1.</Russian>
+			<Chinesesimp>已截图：%1。</Chinesesimp>
+			<Chinese>已截圖：%1。</Chinese>
+			<Japanese>スクリーンショットを撮影しました: %1。</Japanese>
+			<Portuguese>Captura de tela: %1.</Portuguese>
+			<Czech>Snímek obrazovky: %1.</Czech>
+		</Key>
+		<Key ID="STR_KEY_LRX_DIAG_CALLED">
+			<Original>LRX Diag called.</Original>
+			<French>Diagnostic LRX appelé.</French>
+			<German>LRX-Diagnose aufgerufen.</German>
+			<Spanish>Diagnóstico LRX activado.</Spanish>
+			<Russian>Вызван LRX-диагностика.</Russian>
+			<Chinesesimp>已调用 LRX 调试功能。</Chinesesimp>
+			<Chinese>已調用 LRX 調試功能。</Chinese>
+			<Japanese>LRX 診断が呼び出されました。</Japanese>
+			<Portuguese>Diagnóstico LRX acionado.</Portuguese>
+			<Czech>LRX diagnostika spuštěna.</Czech>
+		</Key>
 	</Package>
 	
 	<!-- pSiKO AI Revive -->


### PR DESCRIPTION
Change prompts in multiple files to use the `localize` function for multilingual support:
* Prompt messages in the `do_build_def.sqf` file are localized.
* The prompts in the `do_build_sector_def.sqf` file have been localized.
* The prompts in the `do_clean_def.sqf` file have been localized.
* The prompts in the `officer_init.sqf` file have been localized.

New localized key-value pairs have been added to the `stringtable.xml` file to support the above changes.