### PR TITLE
Fix A3W_sectors_in_use is undefined error on certiain maps

### DIFF
--- a/core.liberation/scripts/client/manager/sides_stats_manager.sqf
+++ b/core.liberation/scripts/client/manager/sides_stats_manager.sqf
@@ -16,7 +16,7 @@ private _stats_marker = [
 
 while { true } do {
 	_msg = "";
-	if (count A3W_sectors_in_use > 0) then {
+	if (!isNil "A3W_sectors_in_use" && {!(A3W_sectors_in_use isEqualTo [])}) then {
 		_all_sectors = (A3W_sectors_in_use select {((markerPos _x) distance2D player) <= GRLIB_capture_size});
 		_sector = [_all_sectors, player] call F_nearestPosition;
 		if (_sector != "") then {


### PR DESCRIPTION
I tried to play the current version on the chernarus 2020 map by AT-Eddy and received the error

A3W_sectors_in_use is undefined

For some reason on this map the server init is slower so this variable can possibly be required by the client before it is broadcast by the server

This fixes the issue by using isnil and lazy evaluation (Without lazy evaluation it would still keep getting undefined so it is important to keep it in the {})